### PR TITLE
Move-Item Move Item to it's own class

### DIFF
--- a/ruby/gilded_rose.rb
+++ b/ruby/gilded_rose.rb
@@ -1,5 +1,4 @@
 class GildedRose
-
   def initialize(items)
     @items = items
   end
@@ -50,19 +49,5 @@ class GildedRose
         end
       end
     end
-  end
-end
-
-class Item
-  attr_accessor :name, :sell_in, :quality
-
-  def initialize(name, sell_in, quality)
-    @name = name
-    @sell_in = sell_in
-    @quality = quality
-  end
-
-  def to_s()
-    "#{@name}, #{@sell_in}, #{@quality}"
   end
 end

--- a/ruby/gilded_rose_spec.rb
+++ b/ruby/gilded_rose_spec.rb
@@ -6,7 +6,7 @@ describe GildedRose do
     it "does not change the name" do
       items = [Item.new("foo", 0, 0)]
       GildedRose.new(items).update_quality()
-      expect(items[0].name).to eq "fixme"
+      expect(items[0].name).to eq "foo"
     end
   end
 

--- a/ruby/gilded_rose_tests.rb
+++ b/ruby/gilded_rose_tests.rb
@@ -6,7 +6,7 @@ class TestUntitled < Test::Unit::TestCase
   def test_foo
     items = [Item.new("foo", 0, 0)]
     GildedRose.new(items).update_quality()
-    assert_equal items[0].name, "fixme"
+    assert_equal items[0].name, "foo"
   end
 
 end

--- a/ruby/item.rb
+++ b/ruby/item.rb
@@ -1,0 +1,13 @@
+class Item
+  attr_accessor :name, :sell_in, :quality
+
+  def initialize(name, sell_in, quality)
+    @name = name
+    @sell_in = sell_in
+    @quality = quality
+  end
+
+  def to_s()
+    "#{@name}, #{@sell_in}, #{@quality}"
+  end
+end

--- a/ruby/texttest_fixture.rb
+++ b/ruby/texttest_fixture.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/ruby -w
 
 require File.join(File.dirname(__FILE__), 'gilded_rose')
+require File.join(File.dirname(__FILE__), 'item')
 
 puts "OMGHAI!"
 items = [


### PR DESCRIPTION
Item should belong in its own class. The idea is to separate item out
of the guilded_rose.rb and into its own file. The tests should still
pass and behaviour should remain the same.